### PR TITLE
github action の修正

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
         with:
-          node-version: '22.14.0'
+          node-version: '22.13.10'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -30,6 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        working-directory: apps/backend
         run: pnpm install --frozen-lockfile
 
       - name: Lint with ESLint

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
         with:
-          node-version: '22.14.0'
+          node-version: '22.13.10'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -30,6 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
+        working-directory: apps/frontend
         run: pnpm install --frozen-lockfile
 
       - name: Lint with ESLint


### PR DESCRIPTION
## 概要
- node.jsのversionを `22.14.0` -> `22.13.0` に修正
- `pnpm-lock.yaml`から依存関係をインストールする時に、ホームディレクトリを見てしまっていたため、
`working-directory` 指定を記述